### PR TITLE
exposes `autoprint` as a method to pass to `win.print()`

### DIFF
--- a/src/resources/api_nw_window.js
+++ b/src/resources/api_nw_window.js
@@ -492,8 +492,10 @@ nw_binding.registerCustomHook(function(bindingsAPI) {
     NWWindow.prototype.cookies = chrome.cookies;
 
     NWWindow.prototype.print = function(option) {
+      if (!option) {
+        option = {'autoprint': false};
+      }
       var _option = JSON.parse(JSON.stringify(option));
-      _option["autoprint"] = true;
       if (option.pdf_path)
         _option["printer"] = "Save as PDF";
       currentNWWindowInternal.setPrintSettingsInternal(_option);


### PR DESCRIPTION
With this, `win.print()` can be called by itself to print the current window, and this also exposes `autoprint` as an option so that you can set it to `false` and still be able to pass other options to it without it going away.

Use case:
Wanting to call `win.print({'autoprint': false, 'shouldPrintBackgrounds': true})`. Previously, you could not have the window dialog open and enabling `shouldPrintBackgrounds` by default.
